### PR TITLE
Ignore .DS_Store and CVS folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+**/.DS_Store
+**/CVS/


### PR DESCRIPTION
### :pencil: Update .gitignore

**Type:**  :memo: `documentation` 

This PR will add `**/.DS_Store` and `**/CVS/` to the `.gitignore` file. These are unwanted files and should not be downloaded while downloading the cmfgen data.




### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [x] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
